### PR TITLE
Add proposal for service schemas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "schema.json" : "*.yaml"
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -70,7 +70,7 @@
                                 "type" : "string"
                             },
                             "mode" : {
-                                "$ref": "#/$defs/AccessMode"
+                                "$ref": "#/$defs/ReadWriteReadwriteAccessMode"
                             }
                         },
                         "additionalProperties" : false,
@@ -82,13 +82,14 @@
                     "items" : {
                         "type" : "object",
                         "properties" : {
-                            "db" : {
+                            "db_name" : {
                                 "type" : "string"
                             },
                             "mode" : {
-                                "$ref": "#/$defs/AccessMode"
+                                "$ref": "#/$defs/ReadReadwriteAccessMode"
                             }
-                        }
+                        },
+                        "additionalProperties" : false
                     }
                 },
                 "vault" : {
@@ -100,9 +101,10 @@
                                 "type" : "string"
                             },
                             "mode" : {
-                                "$ref": "#/$defs/AccessMode"
+                                "$ref": "#/$defs/ReadReadwriteAccessMode"
                             }
-                        }
+                        },
+                        "additionalProperties" : false
                     }
                 }
             },
@@ -159,11 +161,15 @@
                 },
                 "path": {
                     "type": "string"
+                },
+                "authentication": {
+                    "type": "boolean"
                 }
             },
             "required": [
                 "method",
-                "path"
+                "path",
+                "authentication"
             ],
             "additionalProperties": false
         },
@@ -187,7 +193,10 @@
             ],
             "additionalProperties": false
         },
-        "AccessMode" : {
+        "ReadReadwriteAccessMode" : {
+            "enum" : ["read", "read-write"]
+        },
+        "ReadWriteReadwriteAccessMode" : {
             "enum" : ["read", "write", "read-write"]
         }
     }

--- a/schema.json
+++ b/schema.json
@@ -18,37 +18,41 @@
         "command": {
             "type": "string"
         },
-        "consumes": {
+        "api": {
             "type": "object",
             "properties": {
-                "events": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/EventType"
+                "rest" : {
+                    "type" : "object",
+                    "properties" : {
+                        "produces" : {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/RESTEndpointType"
+                            }
+                        },
+                        "consumes" : {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/ConsumedRESTEndpointType"
+                            }
+                        }
                     }
                 },
-                "rest_endpoints": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/ConsumedRESTEndpointType"
-                    }
-                }
-            },
-            "additionalProperties": false
-        },
-        "produces": {
-            "type": "object",
-            "properties": {
-                "events": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/EventType"
-                    }
-                },
-                "rest_endpoints": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/RESTEndpointType"
+                "events" : {
+                    "type" : "object",
+                    "properties" : {
+                        "produces": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/EventType"
+                            }
+                        },
+                        "consumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/EventType"
+                            }
+                        }
                     }
                 }
             },
@@ -104,7 +108,7 @@
             },
             "additionalProperties": false
         },
-        "config" : {
+        "extra_config" : {
             "type" : "array",
             "items" : {
                 "type" : "object",

--- a/schema.json
+++ b/schema.json
@@ -3,14 +3,11 @@
     "title": "Service Integration",
     "type": "object",
     "properties": {
-        "name": {
+        "shortname": {
             "type": "string"
         },
-        "image" : {
+        "name" : {
             "type" : "string"
-        },
-        "description": {
-            "type": "string"
         },
         "summary": {
             "type": "string"
@@ -91,9 +88,8 @@
     },
     "additionalProperties": false,
     "required": [
+        "shortname",
         "name",
-        "image",
-        "description",
         "summary"
     ],
     "$defs": {

--- a/schema.json
+++ b/schema.json
@@ -144,12 +144,16 @@
                 },
                 "config" : {
                     "type" : "string"
+                },
+                "description" : {
+                    "type" : "string"
                 }
             },
             "required": [
                 "topic",
                 "type",
-                "config"
+                "config",
+                "description"
             ],
             "additionalProperties": false
         },

--- a/schema.json
+++ b/schema.json
@@ -12,6 +12,9 @@
         "summary": {
             "type": "string"
         },
+        "version" : {
+            "type" : "string"
+        },
         "command": {
             "type": "string"
         },
@@ -90,7 +93,8 @@
     "required": [
         "shortname",
         "name",
-        "summary"
+        "summary",
+        "version"
     ],
     "$defs": {
         "EventType": {

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,157 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Service Integration",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "image" : {
+            "type" : "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "summary": {
+            "type": "string"
+        },
+        "command": {
+            "type": "string"
+        },
+        "consumes": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/EventType"
+                    }
+                },
+                "rest_endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ConsumedRESTEndpointType"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "produces": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/EventType"
+                    }
+                },
+                "rest_endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/RESTEndpointType"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "storage": {
+            "type": "object",
+            "properties": {
+                "s3": {
+                    "type": "array",
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "bucket" : {
+                                "type" : "string"
+                            },
+                            "mode" : {
+                                "enum" : ["read", "write", "read-write"]
+                            }
+                        },
+                        "additionalProperties" : false,
+                        "required" : ["bucket", "mode"]
+                    }
+                },
+                "mongodb": {
+                    "type": "boolean"
+                },
+                "vault" : {
+                    "type" : "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "config" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string"
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "image",
+        "description",
+        "summary"
+    ],
+    "$defs": {
+        "EventType": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "config" : {
+                    "type" : "string"
+                }
+            },
+            "required": [
+                "topic",
+                "type",
+                "config"
+            ],
+            "additionalProperties": false
+        },
+        "RESTEndpointType": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "method",
+                "path"
+            ],
+            "additionalProperties": false
+        },
+        "ConsumedRESTEndpointType": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type" : "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "service",
+                "method",
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -107,7 +107,15 @@
         "config" : {
             "type" : "array",
             "items" : {
-                "type" : "string"
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "description" : {
+                        "type" : "string"
+                    }
+                }
             }
         }
     },

--- a/schema.json
+++ b/schema.json
@@ -66,7 +66,7 @@
                                 "type" : "string"
                             },
                             "mode" : {
-                                "enum" : ["read", "write", "read-write"]
+                                "$ref": "#/$defs/AccessMode"
                             }
                         },
                         "additionalProperties" : false,
@@ -74,10 +74,32 @@
                     }
                 },
                 "mongodb": {
-                    "type": "boolean"
+                    "type": "array",
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "db" : {
+                                "type" : "string"
+                            },
+                            "mode" : {
+                                "$ref": "#/$defs/AccessMode"
+                            }
+                        }
+                    }
                 },
                 "vault" : {
-                    "type" : "boolean"
+                    "type" : "array",
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "path" : {
+                                "type" : "string"
+                            },
+                            "mode" : {
+                                "$ref": "#/$defs/AccessMode"
+                            }
+                        }
+                    }
                 }
             },
             "additionalProperties": false
@@ -152,6 +174,9 @@
                 "path"
             ],
             "additionalProperties": false
+        },
+        "AccessMode" : {
+            "enum" : ["read", "write", "read-write"]
         }
     }
 }

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,6 +1,7 @@
 shortname: dcs
 name: download-controller-service
 summary: ""
+version: main
 consumes:
   events:
     - topic: internal_file_registry

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -22,10 +22,11 @@ api:
     produces:
       - path: /objects/{object_id}
         method: GET
+        authentication: true
 storage:
   s3:
     - bucket: outbox
       mode: read-write
   mongodb:
-    - db: dcs
+    - db_name: dcs
       mode: read-write

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,7 +1,7 @@
 shortname: dcs
 name: download-controller-service
 summary: ""
-version: main
+version: 0.4.0-14-g4315c66-main
 api:
   events:
     consumes:

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -26,5 +26,5 @@ storage:
     - bucket: outbox
       mode: read-write
   mongodb:
-    - name: dcs
+    - db: dcs
       mode: read-write

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -8,16 +8,20 @@ api:
       - topic: internal_file_registry
         type: file_registered
         config: files_to_register
+        description: Informing about new files that shall be made available for download
     produces:
       - topic: file_downloads
         type: download_served
         config: download_served_event
+        description: Indicating that a download of a specified file happened
       - topic: file_downloads
         type: file_registered
         config: file_registered_event
+        description: Indicating that a file has been registered for download
       - topic: file_downloads
         type: unstaged_download_requested
         config: unstaged_download_event
+        description: Indicating that a download was requested for a file that is not yet available in the outbox
   rest:
     produces:
       - path: /objects/{object_id}

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,0 +1,28 @@
+name: dcs
+image: download-controller-service
+description: Interrogation Room Service
+summary: ""
+consumes:
+  events:
+    - topic: internal_file_registry
+      type: file_registered
+      config: files_to_register
+produces:
+  events:
+    - topic: file_downloads
+      type: download_served
+      config: download_served_event
+    - topic: file_downloads
+      type: file_registered
+      config: file_registered_event
+    - topic: file_downloads
+      type: unstaged_download_requested
+      config: unstaged_download_event
+  rest_endpoints:
+    - path: /objects/{object_id}
+      method: GET
+storage:
+  s3:
+    - bucket: outbox
+      mode: read-write
+  mongodb: true

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -2,25 +2,26 @@ shortname: dcs
 name: download-controller-service
 summary: ""
 version: main
-consumes:
+api:
   events:
-    - topic: internal_file_registry
-      type: file_registered
-      config: files_to_register
-produces:
-  events:
-    - topic: file_downloads
-      type: download_served
-      config: download_served_event
-    - topic: file_downloads
-      type: file_registered
-      config: file_registered_event
-    - topic: file_downloads
-      type: unstaged_download_requested
-      config: unstaged_download_event
-  rest_endpoints:
-    - path: /objects/{object_id}
-      method: GET
+    consumes:
+      - topic: internal_file_registry
+        type: file_registered
+        config: files_to_register
+    produces:
+      - topic: file_downloads
+        type: download_served
+        config: download_served_event
+      - topic: file_downloads
+        type: file_registered
+        config: file_registered_event
+      - topic: file_downloads
+        type: unstaged_download_requested
+        config: unstaged_download_event
+  rest:
+    produces:
+      - path: /objects/{object_id}
+        method: GET
 storage:
   s3:
     - bucket: outbox

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -25,4 +25,6 @@ storage:
   s3:
     - bucket: outbox
       mode: read-write
-  mongodb: true
+  mongodb:
+    - name: dcs
+      mode: read-write

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,6 +1,5 @@
-name: dcs
-image: download-controller-service
-description: Interrogation Room Service
+shortname: dcs
+name: download-controller-service
 summary: ""
 consumes:
   events:

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -2,21 +2,18 @@ shortname: ekss
 name: encryption-key-store-service
 summary: ""
 version: main
-consumes:
-  events: []
-  rest_endpoints: []
-produces:
-  events: []
-  rest_endpoints:
-    - path: /secrets
-      method: POST
-    - path: /secrets/{secret_id}/envelopes/{client_pk}
-      method: GET
+api:
+  rest:
+    produces:
+      - path: /secrets
+        method: POST
+      - path: /secrets/{secret_id}/envelopes/{client_pk}
+        method: GET
 storage:
   vault:
     - path: /cryptkeys
       mode: read-write
-config:
+extra_config:
   - name: server_private_key
     description: The server private key
   - name: server_public_key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,6 +1,5 @@
-name: ekss
-image: encryption-key-store-service
-description: Encryption Key Store Service
+shortname: ekss
+name: encryption-key-store-service
 summary: ""
 consumes:
   events: []

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -17,5 +17,7 @@ storage:
     - path: /cryptkeys
       mode: read-write
 config:
-  - server_private_key
-  - server_public_key
+  - name: server_private_key
+    description: The server private key
+  - name: server_public_key
+    description: The server public key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -7,8 +7,10 @@ api:
     produces:
       - path: /secrets
         method: POST
+        authentication: true
       - path: /secrets/{secret_id}/envelopes/{client_pk}
         method: GET
+        authentication: true
 storage:
   vault:
     - path: /cryptkeys

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,0 +1,19 @@
+name: ekss
+image: encryption-key-store-service
+description: Encryption Key Store Service
+summary: ""
+consumes:
+  events: []
+  rest_endpoints: []
+produces:
+  events: []
+  rest_endpoints:
+    - path: /secrets
+      method: POST
+    - path: /secrets/{secret_id}/envelopes/{client_pk}
+      method: GET
+storage:
+  vault: true
+config:
+  - server_private_key
+  - server_public_key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,6 +1,7 @@
 shortname: ekss
 name: encryption-key-store-service
 summary: ""
+version: main
 consumes:
   events: []
   rest_endpoints: []

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,7 +1,7 @@
 shortname: ekss
 name: encryption-key-store-service
 summary: ""
-version: main
+version: 0.0.0-22-4d92c54-main
 api:
   rest:
     produces:

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -13,7 +13,9 @@ produces:
     - path: /secrets/{secret_id}/envelopes/{client_pk}
       method: GET
 storage:
-  vault: true
+  vault:
+    - path: /cryptkeys
+      mode: read-write
 config:
   - server_private_key
   - server_public_key

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -1,6 +1,5 @@
-name: ifrs
-image: ghga/internal-file-registry-service
-description: Internal File Registry Service
+shortname: ifrs
+name: internal-file-registry-service
 summary: |
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
   pellentesque posuere ante, ac porttitor nulla eleifend quis. Mauris eget

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -7,22 +7,22 @@ summary: |
   lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
   neque hendrerit vulputate non aliquam eros.
 version: main
-produces:
+api:
   events:
-    - topic: internal_file_registry
-      type: file_registered
-      config: file_registered_event
-    - topic: internal_file_registry
-      type: file_staged_for_download
-      config: file_staged_event
-consumes:
-  events:
-    - topic: file_interrogation
-      type: file_validation_success
-      config: files_to_register
-    - topic: file_downloads
-      type: file_stage_requested
-      config: file_to_stage
+    produces:
+      - topic: internal_file_registry
+        type: file_registered
+        config: file_registered_event
+      - topic: internal_file_registry
+        type: file_staged_for_download
+        config: file_staged_event
+    consumes:
+      - topic: file_interrogation
+        type: file_validation_success
+        config: files_to_register
+      - topic: file_downloads
+        type: file_stage_requested
+        config: file_to_stage
 storage:
   mongodb:
     - db: ifrs

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -1,0 +1,36 @@
+name: ifrs
+image: ghga/internal-file-registry-service
+description: Internal File Registry Service
+summary: |
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+  pellentesque posuere ante, ac porttitor nulla eleifend quis. Mauris eget
+  aliquam diam. Duis laoreet blandit luctus. Donec at lacus porta, bibendum
+  lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
+  neque hendrerit vulputate non aliquam eros.
+produces:
+  events:
+    - topic: internal_file_registry
+      type: file_registered
+      config: file_registered_event
+    - topic: internal_file_registry
+      type: file_staged_for_download
+      config: file_staged_event
+consumes:
+  events:
+    - topic: file_interrogation
+      type: file_validation_success
+      config: files_to_register
+    - topic: file_downloads
+      type: file_stage_requested
+      config: file_to_stage
+storage:
+  mongodb: true
+  s3:
+    - bucket: outbox
+      mode: read
+    - bucket: inbox
+      mode: read
+    - bucket: permanent
+      mode: read
+    - bucket: staging
+      mode: read

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -25,7 +25,7 @@ api:
         config: file_to_stage
 storage:
   mongodb:
-    - db: ifrs
+    - db_name: ifrs
       mode: read-write
   s3:
     - bucket: outbox

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -13,16 +13,20 @@ api:
       - topic: internal_file_registry
         type: file_registered
         config: file_registered_event
+        description: Indicating that a new file has been internally registered
       - topic: internal_file_registry
         type: file_staged_for_download
         config: file_staged_event
+        description: Indicating that a new file has been internally registered
     consumes:
       - topic: file_interrogation
         type: file_validation_success
         config: files_to_register
+        description: Informing about new files to register
       - topic: file_downloads
         type: file_stage_requested
-        config: file_to_stage
+        config: files_to_stage
+        description: Informing about a file to be staged
 storage:
   mongodb:
     - db_name: ifrs

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -6,6 +6,7 @@ summary: |
   aliquam diam. Duis laoreet blandit luctus. Donec at lacus porta, bibendum
   lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
   neque hendrerit vulputate non aliquam eros.
+version: main
 produces:
   events:
     - topic: internal_file_registry

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -24,7 +24,9 @@ consumes:
       type: file_stage_requested
       config: file_to_stage
 storage:
-  mongodb: true
+  mongodb:
+    - db: ifrs
+      mode: read-write
   s3:
     - bucket: outbox
       mode: read

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -6,7 +6,7 @@ summary: |
   aliquam diam. Duis laoreet blandit luctus. Donec at lacus porta, bibendum
   lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
   neque hendrerit vulputate non aliquam eros.
-version: main
+version: 0.3.0-20-g82f39eb-main
 api:
   events:
     produces:

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,7 +1,7 @@
 shortname: irs
 name: interrogation-room-service
 summary: ""
-version: main
+version: 0.0.0-19-f87dd1b-main
 api:
   events:
     consumes:

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -2,23 +2,24 @@ shortname: irs
 name: interrogation-room-service
 summary: ""
 version: main
-consumes:
+api:
   events:
-    - topic: file_uploads
-      type: file_upload_received
-      config: upload_received_event
-  rest_endpoints:
-    - service: eks
-      path: /secrets
-      method: POST
-produces:
-  events:
-    - topic: file_interrogation
-      type: file_validation_success
-      config: interrogation_success
-    - topic: file_interrogation
-      type: file_validation_failure
-      config: interrogation_failure
+    consumes:
+      - topic: file_uploads
+        type: file_upload_received
+        config: upload_received_event
+    produces:
+      - topic: file_interrogation
+        type: file_validation_success
+        config: interrogation_success
+      - topic: file_interrogation
+        type: file_validation_failure
+        config: interrogation_failure
+  rest:
+    consumes:
+      - service: eks
+        path: /secrets
+        method: POST
 storage:
   s3:
     - bucket: inbox

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,0 +1,27 @@
+name: irs
+image: interrogation-room-service
+description: Interrogation Room Service
+summary: ""
+consumes:
+  events:
+    - topic: file_uploads
+      type: file_upload_received
+      config: upload_received_event
+  rest_endpoints:
+    - service: eks
+      path: /secrets
+      method: POST
+produces:
+  events:
+    - topic: file_interrogation
+      type: file_validation_success
+      config: interrogation_success
+    - topic: file_interrogation
+      type: file_validation_failure
+      config: interrogation_failure
+storage:
+  s3:
+    - bucket: inbox
+      mode: read
+    - bucket: staging
+      mode: read-write

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -8,13 +8,16 @@ api:
       - topic: file_uploads
         type: file_upload_received
         config: upload_received_event
+        description: Inform about new file uploads
     produces:
       - topic: file_interrogation
         type: file_validation_success
         config: interrogation_success
+        description: Informing about the success of a file validation
       - topic: file_interrogation
         type: file_validation_failure
         config: interrogation_failure
+        description: Informing about the failure of a file validation
   rest:
     consumes:
       - service: eks

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,6 +1,7 @@
 shortname: irs
 name: interrogation-room-service
 summary: ""
+version: main
 consumes:
   events:
     - topic: file_uploads

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,6 +1,5 @@
-name: irs
-image: interrogation-room-service
-description: Interrogation Room Service
+shortname: irs
+name: interrogation-room-service
 summary: ""
 consumes:
   events:

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,0 +1,38 @@
+name: ucs
+image: upload-controller-service
+description: Interrogation Room Service
+summary: ""
+consumes:
+  events:
+    - topic: metadata
+      type: file_metadata_upserts
+      config: file_metadata_event
+    - topic: internal_file_registry
+      type: file_registered
+      config: upload_accepted_event
+    - topic: file_interrogation
+      type: file_validation_failure
+      config: upload_rejected_event
+produces:
+  events:
+    - topic: file_uploads
+      type: file_upload_received
+      config: upload_received_event
+  rest_endpoints:
+    - method: GET
+      path: /files/{file_id}
+    - method: POST
+      path: /uploads
+    - method: GET
+      path: /uploads/{upload_id}
+    - method: PATCH
+      path: /uploads/{upload_id}
+    - method: POST
+      path: /uploads/{upload_id}/parts/{part_no}/signed_urls
+storage:
+  s3:
+    - bucket: inbox
+      mode: read
+    - bucket: staging
+      mode: read
+  mongodb: true

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,7 +1,7 @@
 shortname: ucs
 name: upload-controller-service
 summary: ""
-version: main
+version: 0.3.0-18-g0b8060e-main
 api:
   events:
     consumes:

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -2,33 +2,34 @@ shortname: ucs
 name: upload-controller-service
 summary: ""
 version: main
-consumes:
+api:
   events:
-    - topic: metadata
-      type: file_metadata_upserts
-      config: file_metadata_event
-    - topic: internal_file_registry
-      type: file_registered
-      config: upload_accepted_event
-    - topic: file_interrogation
-      type: file_validation_failure
-      config: upload_rejected_event
-produces:
-  events:
-    - topic: file_uploads
-      type: file_upload_received
-      config: upload_received_event
-  rest_endpoints:
-    - method: GET
-      path: /files/{file_id}
-    - method: POST
-      path: /uploads
-    - method: GET
-      path: /uploads/{upload_id}
-    - method: PATCH
-      path: /uploads/{upload_id}
-    - method: POST
-      path: /uploads/{upload_id}/parts/{part_no}/signed_urls
+    consumes:
+      - topic: metadata
+        type: file_metadata_upserts
+        config: file_metadata_event
+      - topic: internal_file_registry
+        type: file_registered
+        config: upload_accepted_event
+      - topic: file_interrogation
+        type: file_validation_failure
+        config: upload_rejected_event
+    produces:
+      - topic: file_uploads
+        type: file_upload_received
+        config: upload_received_event
+  rest:
+    produces:
+      - method: GET
+        path: /files/{file_id}
+      - method: POST
+        path: /uploads
+      - method: GET
+        path: /uploads/{upload_id}
+      - method: PATCH
+        path: /uploads/{upload_id}
+      - method: POST
+        path: /uploads/{upload_id}/parts/{part_no}/signed_urls
 storage:
   s3:
     - bucket: inbox

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,6 +1,5 @@
-name: ucs
-image: upload-controller-service
-description: Interrogation Room Service
+shortname: ucs
+name: upload-controller-service
 summary: ""
 consumes:
   events:

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -35,4 +35,6 @@ storage:
       mode: read
     - bucket: staging
       mode: read
-  mongodb: true
+  mongodb:
+    - db: ucs
+      mode: read-write

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -22,14 +22,19 @@ api:
     produces:
       - method: GET
         path: /files/{file_id}
+        authentication: true
       - method: POST
         path: /uploads
+        authentication: true
       - method: GET
         path: /uploads/{upload_id}
+        authentication: true
       - method: PATCH
         path: /uploads/{upload_id}
+        authentication: true
       - method: POST
         path: /uploads/{upload_id}/parts/{part_no}/signed_urls
+        authentication: true
 storage:
   s3:
     - bucket: inbox
@@ -37,5 +42,5 @@ storage:
     - bucket: staging
       mode: read
   mongodb:
-    - db: ucs
+    - db_name: ucs
       mode: read-write

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,6 +1,7 @@
 shortname: ucs
 name: upload-controller-service
 summary: ""
+version: main
 consumes:
   events:
     - topic: metadata

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -8,16 +8,20 @@ api:
       - topic: metadata
         type: file_metadata_upserts
         config: file_metadata_event
+        description: New or changed metadata on files that shall be registered for uploaded
       - topic: internal_file_registry
         type: file_registered
         config: upload_accepted_event
+        description: Indicates that an upload was by downstream services
       - topic: file_interrogation
         type: file_validation_failure
         config: upload_rejected_event
+        description: Informing about rejection of an upload by downstream services due to validation failure
     produces:
       - topic: file_uploads
         type: file_upload_received
         config: upload_received_event
+        description: Informing about new file uploads
   rest:
     produces:
       - method: GET


### PR DESCRIPTION
Here's a first draft for a service description format. The design goals included

* enabling some degree of service logic validation, for example whether a consumed event or REST endpoint is actually produced by another service
* enabling the (semi) automatic generation of helm charts, docker compose files etc.
* enabling human readable documentation / visualization of service landscape

I've written a POC parser for the files that auto generates backrefs and infers config options based on endpoint / storage info (backrefs are currently broken) and a demo HTML build process (both not part of this repo / PR). HTML output is visible here:

https://ghga-de.github.io/integration

This PR is primarily to discuss the schema and design goals that should drive the schema, the service yamls are based on the file stack test bed and haven't been validated or reviewed.