### PR TITLE
Feature/add missing services gdev 1673

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "schema.json" : "*.yaml"
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -70,7 +70,7 @@
                                 "type" : "string"
                             },
                             "mode" : {
-                                "$ref": "#/$defs/AccessMode"
+                                "$ref": "#/$defs/ReadWriteReadwriteAccessMode"
                             }
                         },
                         "additionalProperties" : false,
@@ -82,13 +82,14 @@
                     "items" : {
                         "type" : "object",
                         "properties" : {
-                            "db" : {
+                            "db_name" : {
                                 "type" : "string"
                             },
                             "mode" : {
-                                "$ref": "#/$defs/AccessMode"
+                                "$ref": "#/$defs/ReadReadwriteAccessMode"
                             }
-                        }
+                        },
+                        "additionalProperties" : false
                     }
                 },
                 "vault" : {
@@ -100,9 +101,10 @@
                                 "type" : "string"
                             },
                             "mode" : {
-                                "$ref": "#/$defs/AccessMode"
+                                "$ref": "#/$defs/ReadReadwriteAccessMode"
                             }
-                        }
+                        },
+                        "additionalProperties" : false
                     }
                 }
             },
@@ -159,11 +161,15 @@
                 },
                 "path": {
                     "type": "string"
+                },
+                "authentication": {
+                    "type": "boolean"
                 }
             },
             "required": [
                 "method",
-                "path"
+                "path",
+                "authentication"
             ],
             "additionalProperties": false
         },
@@ -187,7 +193,10 @@
             ],
             "additionalProperties": false
         },
-        "AccessMode" : {
+        "ReadReadwriteAccessMode" : {
+            "enum" : ["read", "read-write"]
+        },
+        "ReadWriteReadwriteAccessMode" : {
             "enum" : ["read", "write", "read-write"]
         }
     }

--- a/schema.json
+++ b/schema.json
@@ -18,37 +18,41 @@
         "command": {
             "type": "string"
         },
-        "consumes": {
+        "api": {
             "type": "object",
             "properties": {
-                "events": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/EventType"
+                "rest" : {
+                    "type" : "object",
+                    "properties" : {
+                        "produces" : {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/RESTEndpointType"
+                            }
+                        },
+                        "consumes" : {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/ConsumedRESTEndpointType"
+                            }
+                        }
                     }
                 },
-                "rest_endpoints": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/ConsumedRESTEndpointType"
-                    }
-                }
-            },
-            "additionalProperties": false
-        },
-        "produces": {
-            "type": "object",
-            "properties": {
-                "events": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/EventType"
-                    }
-                },
-                "rest_endpoints": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/RESTEndpointType"
+                "events" : {
+                    "type" : "object",
+                    "properties" : {
+                        "produces": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/EventType"
+                            }
+                        },
+                        "consumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/EventType"
+                            }
+                        }
                     }
                 }
             },
@@ -104,7 +108,7 @@
             },
             "additionalProperties": false
         },
-        "config" : {
+        "extra_config" : {
             "type" : "array",
             "items" : {
                 "type" : "object",

--- a/schema.json
+++ b/schema.json
@@ -3,14 +3,11 @@
     "title": "Service Integration",
     "type": "object",
     "properties": {
-        "name": {
+        "shortname": {
             "type": "string"
         },
-        "image" : {
+        "name" : {
             "type" : "string"
-        },
-        "description": {
-            "type": "string"
         },
         "summary": {
             "type": "string"
@@ -91,9 +88,8 @@
     },
     "additionalProperties": false,
     "required": [
+        "shortname",
         "name",
-        "image",
-        "description",
         "summary"
     ],
     "$defs": {

--- a/schema.json
+++ b/schema.json
@@ -144,12 +144,16 @@
                 },
                 "config" : {
                     "type" : "string"
+                },
+                "description" : {
+                    "type" : "string"
                 }
             },
             "required": [
                 "topic",
                 "type",
-                "config"
+                "config",
+                "description"
             ],
             "additionalProperties": false
         },

--- a/schema.json
+++ b/schema.json
@@ -12,6 +12,9 @@
         "summary": {
             "type": "string"
         },
+        "version" : {
+            "type" : "string"
+        },
         "command": {
             "type": "string"
         },
@@ -90,7 +93,8 @@
     "required": [
         "shortname",
         "name",
-        "summary"
+        "summary",
+        "version"
     ],
     "$defs": {
         "EventType": {

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,157 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Service Integration",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "image" : {
+            "type" : "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "summary": {
+            "type": "string"
+        },
+        "command": {
+            "type": "string"
+        },
+        "consumes": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/EventType"
+                    }
+                },
+                "rest_endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ConsumedRESTEndpointType"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "produces": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/EventType"
+                    }
+                },
+                "rest_endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/RESTEndpointType"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "storage": {
+            "type": "object",
+            "properties": {
+                "s3": {
+                    "type": "array",
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "bucket" : {
+                                "type" : "string"
+                            },
+                            "mode" : {
+                                "enum" : ["read", "write", "read-write"]
+                            }
+                        },
+                        "additionalProperties" : false,
+                        "required" : ["bucket", "mode"]
+                    }
+                },
+                "mongodb": {
+                    "type": "boolean"
+                },
+                "vault" : {
+                    "type" : "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "config" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string"
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "image",
+        "description",
+        "summary"
+    ],
+    "$defs": {
+        "EventType": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "config" : {
+                    "type" : "string"
+                }
+            },
+            "required": [
+                "topic",
+                "type",
+                "config"
+            ],
+            "additionalProperties": false
+        },
+        "RESTEndpointType": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "method",
+                "path"
+            ],
+            "additionalProperties": false
+        },
+        "ConsumedRESTEndpointType": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type" : "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "service",
+                "method",
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -107,7 +107,15 @@
         "config" : {
             "type" : "array",
             "items" : {
-                "type" : "string"
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "description" : {
+                        "type" : "string"
+                    }
+                }
             }
         }
     },

--- a/schema.json
+++ b/schema.json
@@ -66,7 +66,7 @@
                                 "type" : "string"
                             },
                             "mode" : {
-                                "enum" : ["read", "write", "read-write"]
+                                "$ref": "#/$defs/AccessMode"
                             }
                         },
                         "additionalProperties" : false,
@@ -74,10 +74,32 @@
                     }
                 },
                 "mongodb": {
-                    "type": "boolean"
+                    "type": "array",
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "db" : {
+                                "type" : "string"
+                            },
+                            "mode" : {
+                                "$ref": "#/$defs/AccessMode"
+                            }
+                        }
+                    }
                 },
                 "vault" : {
-                    "type" : "boolean"
+                    "type" : "array",
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "path" : {
+                                "type" : "string"
+                            },
+                            "mode" : {
+                                "$ref": "#/$defs/AccessMode"
+                            }
+                        }
+                    }
                 }
             },
             "additionalProperties": false
@@ -152,6 +174,9 @@
                 "path"
             ],
             "additionalProperties": false
+        },
+        "AccessMode" : {
+            "enum" : ["read", "write", "read-write"]
         }
     }
 }

--- a/services/as.yaml
+++ b/services/as.yaml
@@ -1,0 +1,59 @@
+shortname: as
+name: auth-service
+summary: |
+  This service contains two sub-services for the management, authentication 
+  and authorization of users of the GHGA data portal. The `auth_adapter` 
+  subpackage contains the authentication service used by the API gateway 
+  via the ExtAuth protocol. The `user_management` subpackage contains the 
+  user data management service. The setting `run_auth_adapter` can be used to 
+  determine which of the two services will be started.
+version: main
+api:
+  rest:
+    produces:
+      - path: /users
+        method: POST
+        authentication: true
+      - path: /users/{id}
+        method: DELETE
+        authentication: true
+      - path: /users/{id}
+        method: GET
+        authentication: true
+      - path: /users/{id}
+        method: PATCH
+        authentication: true
+      - path: /users/{id}
+        method: PUT
+        authentication: true
+      - path: /users/{user_id}/claims
+        method: GET
+        authentication: true
+      - path: /users/{user_id}/claims
+        method: POST
+        authentication: true
+      - path: /users/{user_id}/claims/{claim_id}
+        method: DELETE
+        authentication: true
+      - path: /users/{user_id}/claims/{claim_id}
+        method: PATCH
+        authentication: true
+storage:
+  mongodb:
+    - db_name: auth_service
+      mode: read-write
+extra_config:
+    - name: auth_int_keys
+      description: Internal public key for user management
+    - name: auth_ext_keys
+      description: External public key set for auth adapter
+    - name: auth_ext_algs
+      description: Allowed algorithms for signing external tokens
+    - name: basic_auth_user
+      description: User(s) for basic authentication
+    - name: basic_auth_pwd
+      description: Password(s) for basic authentication
+    - name: oidc_authority_url
+      description: OIDC Authority Url
+    - name: oidc_client_id
+      description: OIDC Client Id

--- a/services/as.yaml
+++ b/services/as.yaml
@@ -1,12 +1,11 @@
 shortname: as
 name: auth-service
-summary: |
-  This service contains two sub-services for the management, authentication 
-  and authorization of users of the GHGA data portal. The `auth_adapter` 
-  subpackage contains the authentication service used by the API gateway 
-  via the ExtAuth protocol. The `user_management` subpackage contains the 
-  user data management service. The setting `run_auth_adapter` can be used to 
-  determine which of the two services will be started.
+summary: "This service contains two sub-services for the management, authentication 
+          and authorization of users of the GHGA data portal. The `auth_adapter` 
+          subpackage contains the authentication service used by the API gateway 
+          via the ExtAuth protocol. The `user_management` subpackage contains the 
+          user data management service. The setting `run_auth_adapter` can be used to 
+          determine which of the two services will be started."
 version: main
 api:
   rest:

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,6 +1,7 @@
 shortname: dcs
 name: download-controller-service
 summary: ""
+version: main
 consumes:
   events:
     - topic: internal_file_registry

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -22,10 +22,11 @@ api:
     produces:
       - path: /objects/{object_id}
         method: GET
+        authentication: true
 storage:
   s3:
     - bucket: outbox
       mode: read-write
   mongodb:
-    - db: dcs
+    - db_name: dcs
       mode: read-write

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,6 +1,8 @@
 shortname: dcs
 name: download-controller-service
-summary: ""
+summary: |
+  Download Controller Service (DRS) implements the GA4GH DRS, 
+  while providing the option to serve files from localstack S3.
 version: main
 api:
   events:
@@ -27,6 +29,10 @@ api:
       - path: /objects/{object_id}
         method: GET
         authentication: true
+    consumes:
+      - service: ekss
+        path: /secrets/{secret_id}/envelopes/{client_pk}
+        method: GET
 storage:
   s3:
     - bucket: outbox

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -26,5 +26,5 @@ storage:
     - bucket: outbox
       mode: read-write
   mongodb:
-    - name: dcs
+    - db: dcs
       mode: read-write

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -8,16 +8,20 @@ api:
       - topic: internal_file_registry
         type: file_registered
         config: files_to_register
+        description: Informing about new files that shall be made available for download
     produces:
       - topic: file_downloads
         type: download_served
         config: download_served_event
+        description: Indicating that a download of a specified file happened
       - topic: file_downloads
         type: file_registered
         config: file_registered_event
+        description: Indicating that a file has been registered for download
       - topic: file_downloads
         type: unstaged_download_requested
         config: unstaged_download_event
+        description: Indicating that a download was requested for a file that is not yet available in the outbox
   rest:
     produces:
       - path: /objects/{object_id}

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,8 +1,7 @@
 shortname: dcs
 name: download-controller-service
-summary: |
-  Download Controller Service (DRS) implements the GA4GH DRS, 
-  while providing the option to serve files from localstack S3.
+summary: "Download Controller Service (DRS) implements the GA4GH DRS, 
+          while providing the option to serve files from localstack S3."
 version: main
 api:
   events:

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,0 +1,28 @@
+name: dcs
+image: download-controller-service
+description: Interrogation Room Service
+summary: ""
+consumes:
+  events:
+    - topic: internal_file_registry
+      type: file_registered
+      config: files_to_register
+produces:
+  events:
+    - topic: file_downloads
+      type: download_served
+      config: download_served_event
+    - topic: file_downloads
+      type: file_registered
+      config: file_registered_event
+    - topic: file_downloads
+      type: unstaged_download_requested
+      config: unstaged_download_event
+  rest_endpoints:
+    - path: /objects/{object_id}
+      method: GET
+storage:
+  s3:
+    - bucket: outbox
+      mode: read-write
+  mongodb: true

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -2,25 +2,26 @@ shortname: dcs
 name: download-controller-service
 summary: ""
 version: main
-consumes:
+api:
   events:
-    - topic: internal_file_registry
-      type: file_registered
-      config: files_to_register
-produces:
-  events:
-    - topic: file_downloads
-      type: download_served
-      config: download_served_event
-    - topic: file_downloads
-      type: file_registered
-      config: file_registered_event
-    - topic: file_downloads
-      type: unstaged_download_requested
-      config: unstaged_download_event
-  rest_endpoints:
-    - path: /objects/{object_id}
-      method: GET
+    consumes:
+      - topic: internal_file_registry
+        type: file_registered
+        config: files_to_register
+    produces:
+      - topic: file_downloads
+        type: download_served
+        config: download_served_event
+      - topic: file_downloads
+        type: file_registered
+        config: file_registered_event
+      - topic: file_downloads
+        type: unstaged_download_requested
+        config: unstaged_download_event
+  rest:
+    produces:
+      - path: /objects/{object_id}
+        method: GET
 storage:
   s3:
     - bucket: outbox

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -25,4 +25,6 @@ storage:
   s3:
     - bucket: outbox
       mode: read-write
-  mongodb: true
+  mongodb:
+    - name: dcs
+      mode: read-write

--- a/services/dcs.yaml
+++ b/services/dcs.yaml
@@ -1,6 +1,5 @@
-name: dcs
-image: download-controller-service
-description: Interrogation Room Service
+shortname: dcs
+name: download-controller-service
 summary: ""
 consumes:
   events:

--- a/services/dpu.yaml
+++ b/services/dpu.yaml
@@ -1,0 +1,11 @@
+shortname: dpu
+name: data-portal-ui
+summary: |
+  GHGA Data Portal front end interface
+version: main
+api:
+  rest:
+    consumes:
+      - service: mrs
+        path: /metadata_summary
+        method: GET

--- a/services/dpu.yaml
+++ b/services/dpu.yaml
@@ -1,7 +1,6 @@
 shortname: dpu
 name: data-portal-ui
-summary: |
-  GHGA Data Portal front end interface
+summary: "GHGA Data Portal front end interface"
 version: main
 api:
   rest:
@@ -9,3 +8,4 @@ api:
       - service: mrs
         path: /metadata_summary
         method: GET
+storage: {}

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -2,21 +2,18 @@ shortname: ekss
 name: encryption-key-store-service
 summary: ""
 version: main
-consumes:
-  events: []
-  rest_endpoints: []
-produces:
-  events: []
-  rest_endpoints:
-    - path: /secrets
-      method: POST
-    - path: /secrets/{secret_id}/envelopes/{client_pk}
-      method: GET
+api:
+  rest:
+    produces:
+      - path: /secrets
+        method: POST
+      - path: /secrets/{secret_id}/envelopes/{client_pk}
+        method: GET
 storage:
   vault:
     - path: /cryptkeys
       mode: read-write
-config:
+extra_config:
   - name: server_private_key
     description: The server private key
   - name: server_public_key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,6 +1,5 @@
-name: ekss
-image: encryption-key-store-service
-description: Encryption Key Store Service
+shortname: ekss
+name: encryption-key-store-service
 summary: ""
 consumes:
   events: []

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -17,5 +17,7 @@ storage:
     - path: /cryptkeys
       mode: read-write
 config:
-  - server_private_key
-  - server_public_key
+  - name: server_private_key
+    description: The server private key
+  - name: server_public_key
+    description: The server public key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -7,8 +7,10 @@ api:
     produces:
       - path: /secrets
         method: POST
+        authentication: true
       - path: /secrets/{secret_id}/envelopes/{client_pk}
         method: GET
+        authentication: true
 storage:
   vault:
     - path: /cryptkeys

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,0 +1,19 @@
+name: ekss
+image: encryption-key-store-service
+description: Encryption Key Store Service
+summary: ""
+consumes:
+  events: []
+  rest_endpoints: []
+produces:
+  events: []
+  rest_endpoints:
+    - path: /secrets
+      method: POST
+    - path: /secrets/{secret_id}/envelopes/{client_pk}
+      method: GET
+storage:
+  vault: true
+config:
+  - server_private_key
+  - server_public_key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,9 +1,8 @@
 shortname: ekss
 name: encryption-key-store-service
-summary: |
-  The Encryption Key Store Service (EKS) handles storage and retrieval 
-  of encryption/decryption secrets, extraction of information from and 
-  creation of personalized Crypt4GH file envelopes.
+summary: "The Encryption Key Store Service (EKS) handles storage and retrieval 
+          of encryption/decryption secrets, extraction of information from and 
+          creation of personalized Crypt4GH file envelopes."
 version: main
 api:
   rest:

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,6 +1,7 @@
 shortname: ekss
 name: encryption-key-store-service
 summary: ""
+version: main
 consumes:
   events: []
   rest_endpoints: []

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -13,7 +13,9 @@ produces:
     - path: /secrets/{secret_id}/envelopes/{client_pk}
       method: GET
 storage:
-  vault: true
+  vault:
+    - path: /cryptkeys
+      mode: read-write
 config:
   - server_private_key
   - server_public_key

--- a/services/ekss.yaml
+++ b/services/ekss.yaml
@@ -1,6 +1,9 @@
 shortname: ekss
 name: encryption-key-store-service
-summary: ""
+summary: |
+  The Encryption Key Store Service (EKS) handles storage and retrieval 
+  of encryption/decryption secrets, extraction of information from and 
+  creation of personalized Crypt4GH file envelopes.
 version: main
 api:
   rest:

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -1,6 +1,5 @@
-name: ifrs
-image: ghga/internal-file-registry-service
-description: Internal File Registry Service
+shortname: ifrs
+name: internal-file-registry-service
 summary: |
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
   pellentesque posuere ante, ac porttitor nulla eleifend quis. Mauris eget

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -1,13 +1,12 @@
 shortname: ifrs
 name: internal-file-registry-service
-summary: |
-  This service acts as a registry for the internal location and 
-  representation of files. Upon providing an internal file ID, 
-  it delivers a URL to the corresponding file. If the file is 
-  located on a permanent storage system that is not accessible 
-  to other services (i.e. not S3, e.g. a flat-file system), 
-  this service SHOULD stage the file into an accessible S3-based 
-  storage system and serve the location to the staged file.
+summary: "This service acts as a registry for the internal location and 
+          representation of files. Upon providing an internal file ID, 
+          it delivers a URL to the corresponding file. If the file is 
+          located on a permanent storage system that is not accessible 
+          to other services (i.e. not S3, e.g. a flat-file system), 
+          this service SHOULD stage the file into an accessible S3-based 
+          storage system and serve the location to the staged file."
 version: main
 api:
   events:

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -7,22 +7,22 @@ summary: |
   lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
   neque hendrerit vulputate non aliquam eros.
 version: main
-produces:
+api:
   events:
-    - topic: internal_file_registry
-      type: file_registered
-      config: file_registered_event
-    - topic: internal_file_registry
-      type: file_staged_for_download
-      config: file_staged_event
-consumes:
-  events:
-    - topic: file_interrogation
-      type: file_validation_success
-      config: files_to_register
-    - topic: file_downloads
-      type: file_stage_requested
-      config: file_to_stage
+    produces:
+      - topic: internal_file_registry
+        type: file_registered
+        config: file_registered_event
+      - topic: internal_file_registry
+        type: file_staged_for_download
+        config: file_staged_event
+    consumes:
+      - topic: file_interrogation
+        type: file_validation_success
+        config: files_to_register
+      - topic: file_downloads
+        type: file_stage_requested
+        config: file_to_stage
 storage:
   mongodb:
     - db: ifrs

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -1,0 +1,36 @@
+name: ifrs
+image: ghga/internal-file-registry-service
+description: Internal File Registry Service
+summary: |
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+  pellentesque posuere ante, ac porttitor nulla eleifend quis. Mauris eget
+  aliquam diam. Duis laoreet blandit luctus. Donec at lacus porta, bibendum
+  lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
+  neque hendrerit vulputate non aliquam eros.
+produces:
+  events:
+    - topic: internal_file_registry
+      type: file_registered
+      config: file_registered_event
+    - topic: internal_file_registry
+      type: file_staged_for_download
+      config: file_staged_event
+consumes:
+  events:
+    - topic: file_interrogation
+      type: file_validation_success
+      config: files_to_register
+    - topic: file_downloads
+      type: file_stage_requested
+      config: file_to_stage
+storage:
+  mongodb: true
+  s3:
+    - bucket: outbox
+      mode: read
+    - bucket: inbox
+      mode: read
+    - bucket: permanent
+      mode: read
+    - bucket: staging
+      mode: read

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -25,7 +25,7 @@ api:
         config: file_to_stage
 storage:
   mongodb:
-    - db: ifrs
+    - db_name: ifrs
       mode: read-write
   s3:
     - bucket: outbox

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -13,16 +13,20 @@ api:
       - topic: internal_file_registry
         type: file_registered
         config: file_registered_event
+        description: Indicating that a new file has been internally registered
       - topic: internal_file_registry
         type: file_staged_for_download
         config: file_staged_event
+        description: Indicating that a new file has been internally registered
     consumes:
       - topic: file_interrogation
         type: file_validation_success
         config: files_to_register
+        description: Informing about new files to register
       - topic: file_downloads
         type: file_stage_requested
-        config: file_to_stage
+        config: files_to_stage
+        description: Informing about a file to be staged
 storage:
   mongodb:
     - db_name: ifrs

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -6,6 +6,7 @@ summary: |
   aliquam diam. Duis laoreet blandit luctus. Donec at lacus porta, bibendum
   lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
   neque hendrerit vulputate non aliquam eros.
+version: main
 produces:
   events:
     - topic: internal_file_registry

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -1,11 +1,13 @@
 shortname: ifrs
 name: internal-file-registry-service
 summary: |
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
-  pellentesque posuere ante, ac porttitor nulla eleifend quis. Mauris eget
-  aliquam diam. Duis laoreet blandit luctus. Donec at lacus porta, bibendum
-  lectus dignissim, eleifend est. Etiam sit amet blandit dui. Cras id ante et
-  neque hendrerit vulputate non aliquam eros.
+  This service acts as a registry for the internal location and 
+  representation of files. Upon providing an internal file ID, 
+  it delivers a URL to the corresponding file. If the file is 
+  located on a permanent storage system that is not accessible 
+  to other services (i.e. not S3, e.g. a flat-file system), 
+  this service SHOULD stage the file into an accessible S3-based 
+  storage system and serve the location to the staged file.
 version: main
 api:
   events:

--- a/services/ifrs.yaml
+++ b/services/ifrs.yaml
@@ -24,7 +24,9 @@ consumes:
       type: file_stage_requested
       config: file_to_stage
 storage:
-  mongodb: true
+  mongodb:
+    - db: ifrs
+      mode: read-write
   s3:
     - bucket: outbox
       mode: read

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,6 +1,13 @@
 shortname: irs
 name: interrogation-room-service
-summary: ""
+summary: |
+  The Interrogation Room Service (IRS) interfaces with the 
+  Encryption Key Store Service to process Crypt4GH encrypted 
+  files uploaded to the inbox of a local GHGA node. The IRS 
+  splits off the file envelope, computes part checksums over 
+  the encrypted file content, validates the checksum over the 
+  unencrypted file content (in memory) and initiates transfer 
+  of the encrypted file content to its permanent storage.
 version: main
 api:
   events:

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -2,23 +2,24 @@ shortname: irs
 name: interrogation-room-service
 summary: ""
 version: main
-consumes:
+api:
   events:
-    - topic: file_uploads
-      type: file_upload_received
-      config: upload_received_event
-  rest_endpoints:
-    - service: eks
-      path: /secrets
-      method: POST
-produces:
-  events:
-    - topic: file_interrogation
-      type: file_validation_success
-      config: interrogation_success
-    - topic: file_interrogation
-      type: file_validation_failure
-      config: interrogation_failure
+    consumes:
+      - topic: file_uploads
+        type: file_upload_received
+        config: upload_received_event
+    produces:
+      - topic: file_interrogation
+        type: file_validation_success
+        config: interrogation_success
+      - topic: file_interrogation
+        type: file_validation_failure
+        config: interrogation_failure
+  rest:
+    consumes:
+      - service: eks
+        path: /secrets
+        method: POST
 storage:
   s3:
     - bucket: inbox

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,0 +1,27 @@
+name: irs
+image: interrogation-room-service
+description: Interrogation Room Service
+summary: ""
+consumes:
+  events:
+    - topic: file_uploads
+      type: file_upload_received
+      config: upload_received_event
+  rest_endpoints:
+    - service: eks
+      path: /secrets
+      method: POST
+produces:
+  events:
+    - topic: file_interrogation
+      type: file_validation_success
+      config: interrogation_success
+    - topic: file_interrogation
+      type: file_validation_failure
+      config: interrogation_failure
+storage:
+  s3:
+    - bucket: inbox
+      mode: read
+    - bucket: staging
+      mode: read-write

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -8,13 +8,16 @@ api:
       - topic: file_uploads
         type: file_upload_received
         config: upload_received_event
+        description: Inform about new file uploads
     produces:
       - topic: file_interrogation
         type: file_validation_success
         config: interrogation_success
+        description: Informing about the success of a file validation
       - topic: file_interrogation
         type: file_validation_failure
         config: interrogation_failure
+        description: Informing about the failure of a file validation
   rest:
     consumes:
       - service: eks

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,6 +1,7 @@
 shortname: irs
 name: interrogation-room-service
 summary: ""
+version: main
 consumes:
   events:
     - topic: file_uploads

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,6 +1,5 @@
-name: irs
-image: interrogation-room-service
-description: Interrogation Room Service
+shortname: irs
+name: interrogation-room-service
 summary: ""
 consumes:
   events:

--- a/services/irs.yaml
+++ b/services/irs.yaml
@@ -1,13 +1,12 @@
 shortname: irs
 name: interrogation-room-service
-summary: |
-  The Interrogation Room Service (IRS) interfaces with the 
-  Encryption Key Store Service to process Crypt4GH encrypted 
-  files uploaded to the inbox of a local GHGA node. The IRS 
-  splits off the file envelope, computes part checksums over 
-  the encrypted file content, validates the checksum over the 
-  unencrypted file content (in memory) and initiates transfer 
-  of the encrypted file content to its permanent storage.
+summary: "The Interrogation Room Service (IRS) interfaces with the 
+          Encryption Key Store Service to process Crypt4GH encrypted 
+          files uploaded to the inbox of a local GHGA node. The IRS 
+          splits off the file envelope, computes part checksums over 
+          the encrypted file content, validates the checksum over the 
+          unencrypted file content (in memory) and initiates transfer 
+          of the encrypted file content to its permanent storage."
 version: main
 api:
   events:

--- a/services/mc.yaml
+++ b/services/mc.yaml
@@ -1,0 +1,20 @@
+shortname: mc
+name: metadata-catalog
+summary: |
+  GHGA Metadata Catalog front end interface
+version: main
+api:
+  rest:
+    consumes:
+      - service: mss
+        path:  /rpc/search
+        method: POST
+      - service: mrs
+        path: /datasets/{dataset_id}
+        method: GET
+      - service: mrs
+        path: /dataset_summary/{dataset_id}
+        method: POST
+      - service: mrs
+        path: /metadata_summary
+        method: GET

--- a/services/mc.yaml
+++ b/services/mc.yaml
@@ -1,7 +1,6 @@
 shortname: mc
 name: metadata-catalog
-summary: |
-  GHGA Metadata Catalog front end interface
+summary: "GHGA Metadata Catalog front end interface"
 version: main
 api:
   rest:
@@ -14,7 +13,8 @@ api:
         method: GET
       - service: mrs
         path: /dataset_summary/{dataset_id}
-        method: POST
+        method: GET
       - service: mrs
         path: /metadata_summary
         method: GET
+storage: {}

--- a/services/mrs.yaml
+++ b/services/mrs.yaml
@@ -1,12 +1,11 @@
 shortname: mrs
 name: metadata-repository-service
-summary: |
-  The Metadata Repository Service (MRS) is storing study or 
-  dataset-related metadata and implements a RESTful API for 
-  controlled submission and manipulation of this metadata. 
-  The service is also responsible for validating the incoming 
-  metadata JSON and ensuring that the metadata records are 
-  conformant to the GHGA Metadata Schema.
+summary: "The Metadata Repository Service (MRS) is storing study or 
+          dataset-related metadata and implements a RESTful API for 
+          controlled submission and manipulation of this metadata. 
+          The service is also responsible for validating the incoming 
+          metadata JSON and ensuring that the metadata records are 
+          conformant to the GHGA Metadata Schema."
 version: main
 api:
   rest:

--- a/services/mrs.yaml
+++ b/services/mrs.yaml
@@ -1,0 +1,104 @@
+shortname: mrs
+name: metadata-repository-service
+summary: |
+  The Metadata Repository Service (MRS) is storing study or 
+  dataset-related metadata and implements a RESTful API for 
+  controlled submission and manipulation of this metadata. 
+  The service is also responsible for validating the incoming 
+  metadata JSON and ensuring that the metadata records are 
+  conformant to the GHGA Metadata Schema.
+version: main
+api:
+  rest:
+    produces:
+      - method: GET
+        path: /
+        authentication: true
+      - method: GET
+        path: /analyses/{analysis_id}
+        authentication: true
+      - method: GET
+        path: /analysis_process/{analysis_process_id}
+        authentication: true
+      - method: GET
+        path: /biospecimens/{biospecimen_id}
+        authentication: true
+      - method: POST
+        path: /data_access_committees
+        authentication: true
+      - method: GET
+        path: /data_access_committees/{data_access_committee_id}
+        authentication: true
+      - method: POST
+        path: /data_access_policies
+        authentication: true
+      - method: GET
+        path: /data_access_policies/{data_access_policy_id}
+        authentication: true
+      - method: GET
+        path: /dataset_summary/{dataset_id}
+        authentication: true
+      - method: POST
+        path: /datasets
+        authentication: true
+      - method: PATCH
+        path: /datasets/{dataset_accession}
+        authentication: true
+      - method: GET
+        path: /datasets/{dataset_id}
+        authentication: true
+      - method: GET
+        path: /experiment_processes/{experiment_process_id}
+        authentication: true
+      - method: GET
+        path: /experiments/{experiment_id}
+        authentication: true
+      - method: GET
+        path: /files/{file_id}
+        authentication: true
+      - method: GET
+        path: /individuals/{individual_id}
+        authentication: true
+      - method: GET
+        path: /members/{member_id}
+        authentication: true
+      - method: GET
+        path: /metadata_summary/
+        authentication: true
+      - method: GET
+        path: /projects/{project_id}
+        authentication: true
+      - method: GET
+        path: /protocols/{protocol_id}
+        authentication: true
+      - method: GET
+        path: /publications/{publication_id}
+        authentication: true
+      - method: GET
+        path: /samples/{sample_id}
+        authentication: true
+      - method: GET
+        path: /studies/{study_id}
+        authentication: true
+      - method: POST
+        path: /submissions
+        authentication: true
+      - method: GET
+        path: /submissions/{submission_id}
+        authentication: true
+      - method: PATCH
+        path: /submissions/{submission_id}
+        authentication: true
+      - method: PUT
+        path: /submissions/{submission_id}
+        authentication: true
+      - method: GET
+        path: /technologies/{technology_id}
+        authentication: true
+      - method: GET
+        path: /workflows/{workflow_id}
+        authentication: true
+storage:
+  mongodb:
+    - db_name: metadata_repository_service
+      mode: read-write

--- a/services/mss.yaml
+++ b/services/mss.yaml
@@ -1,0 +1,19 @@
+shortname: mss
+name: metadata-search-service
+summary: |
+  The Metadata Search Service (MRS) is a service for providing 
+  a unified search interface over a metadata store.
+version: main
+api:
+  rest:
+    produces:
+      - path: /
+        method: GET
+        authentication: true
+      - path: /rpc/search
+        method: POST
+        authentication: true
+storage:
+  mongodb:
+    - db_name: metadata_search_service
+      mode: read-write

--- a/services/mss.yaml
+++ b/services/mss.yaml
@@ -1,8 +1,7 @@
 shortname: mss
 name: metadata-search-service
-summary: |
-  The Metadata Search Service (MRS) is a service for providing 
-  a unified search interface over a metadata store.
+summary: "The Metadata Search Service (MRS) is a service for providing 
+          a unified search interface over a metadata store."
 version: main
 api:
   rest:

--- a/services/mts.yaml
+++ b/services/mts.yaml
@@ -1,0 +1,17 @@
+shortname: mts
+name: metadata-transpiler-service
+summary: |
+  The Metadata Transpiler Service (MTS) transforms the submitted 
+  metadata into a Submission JSON, which can be later submitted 
+  to Metadata Repository Service. At the moment MTS can convert 
+  the metadata submitted in the user friendly spreadsheet form to JSON.
+version: main
+api:
+  rest:
+    produces:
+      - method: GET
+        path: /
+        authentication: true
+      - method: POST
+        path: /convert
+        authentication: true

--- a/services/mts.yaml
+++ b/services/mts.yaml
@@ -1,10 +1,9 @@
 shortname: mts
 name: metadata-transpiler-service
-summary: |
-  The Metadata Transpiler Service (MTS) transforms the submitted 
-  metadata into a Submission JSON, which can be later submitted 
-  to Metadata Repository Service. At the moment MTS can convert 
-  the metadata submitted in the user friendly spreadsheet form to JSON.
+summary: "The Metadata Transpiler Service (MTS) transforms the submitted 
+          metadata into a Submission JSON, which can be later submitted 
+          to Metadata Repository Service. At the moment MTS can convert 
+          the metadata submitted in the user friendly spreadsheet form to JSON."
 version: main
 api:
   rest:
@@ -15,3 +14,4 @@ api:
       - method: POST
         path: /convert
         authentication: true
+storage: {}

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,0 +1,38 @@
+name: ucs
+image: upload-controller-service
+description: Interrogation Room Service
+summary: ""
+consumes:
+  events:
+    - topic: metadata
+      type: file_metadata_upserts
+      config: file_metadata_event
+    - topic: internal_file_registry
+      type: file_registered
+      config: upload_accepted_event
+    - topic: file_interrogation
+      type: file_validation_failure
+      config: upload_rejected_event
+produces:
+  events:
+    - topic: file_uploads
+      type: file_upload_received
+      config: upload_received_event
+  rest_endpoints:
+    - method: GET
+      path: /files/{file_id}
+    - method: POST
+      path: /uploads
+    - method: GET
+      path: /uploads/{upload_id}
+    - method: PATCH
+      path: /uploads/{upload_id}
+    - method: POST
+      path: /uploads/{upload_id}/parts/{part_no}/signed_urls
+storage:
+  s3:
+    - bucket: inbox
+      mode: read
+    - bucket: staging
+      mode: read
+  mongodb: true

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,7 +1,6 @@
 shortname: ucs
 name: upload-controller-service
-summary: |
-  The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket.
+summary: "The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket."
 version: main
 api:
   events:

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -2,33 +2,34 @@ shortname: ucs
 name: upload-controller-service
 summary: ""
 version: main
-consumes:
+api:
   events:
-    - topic: metadata
-      type: file_metadata_upserts
-      config: file_metadata_event
-    - topic: internal_file_registry
-      type: file_registered
-      config: upload_accepted_event
-    - topic: file_interrogation
-      type: file_validation_failure
-      config: upload_rejected_event
-produces:
-  events:
-    - topic: file_uploads
-      type: file_upload_received
-      config: upload_received_event
-  rest_endpoints:
-    - method: GET
-      path: /files/{file_id}
-    - method: POST
-      path: /uploads
-    - method: GET
-      path: /uploads/{upload_id}
-    - method: PATCH
-      path: /uploads/{upload_id}
-    - method: POST
-      path: /uploads/{upload_id}/parts/{part_no}/signed_urls
+    consumes:
+      - topic: metadata
+        type: file_metadata_upserts
+        config: file_metadata_event
+      - topic: internal_file_registry
+        type: file_registered
+        config: upload_accepted_event
+      - topic: file_interrogation
+        type: file_validation_failure
+        config: upload_rejected_event
+    produces:
+      - topic: file_uploads
+        type: file_upload_received
+        config: upload_received_event
+  rest:
+    produces:
+      - method: GET
+        path: /files/{file_id}
+      - method: POST
+        path: /uploads
+      - method: GET
+        path: /uploads/{upload_id}
+      - method: PATCH
+        path: /uploads/{upload_id}
+      - method: POST
+        path: /uploads/{upload_id}/parts/{part_no}/signed_urls
 storage:
   s3:
     - bucket: inbox

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,6 +1,5 @@
-name: ucs
-image: upload-controller-service
-description: Interrogation Room Service
+shortname: ucs
+name: upload-controller-service
 summary: ""
 consumes:
   events:

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,6 +1,7 @@
 shortname: ucs
 name: upload-controller-service
-summary: ""
+summary: |
+  The Upload-Controller Service (UCS) manages uploads to a S3 inbox bucket.
 version: main
 api:
   events:

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -35,4 +35,6 @@ storage:
       mode: read
     - bucket: staging
       mode: read
-  mongodb: true
+  mongodb:
+    - db: ucs
+      mode: read-write

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -22,14 +22,19 @@ api:
     produces:
       - method: GET
         path: /files/{file_id}
+        authentication: true
       - method: POST
         path: /uploads
+        authentication: true
       - method: GET
         path: /uploads/{upload_id}
+        authentication: true
       - method: PATCH
         path: /uploads/{upload_id}
+        authentication: true
       - method: POST
         path: /uploads/{upload_id}/parts/{part_no}/signed_urls
+        authentication: true
 storage:
   s3:
     - bucket: inbox
@@ -37,5 +42,5 @@ storage:
     - bucket: staging
       mode: read
   mongodb:
-    - db: ucs
+    - db_name: ucs
       mode: read-write

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -1,6 +1,7 @@
 shortname: ucs
 name: upload-controller-service
 summary: ""
+version: main
 consumes:
   events:
     - topic: metadata

--- a/services/ucs.yaml
+++ b/services/ucs.yaml
@@ -8,16 +8,20 @@ api:
       - topic: metadata
         type: file_metadata_upserts
         config: file_metadata_event
+        description: New or changed metadata on files that shall be registered for uploaded
       - topic: internal_file_registry
         type: file_registered
         config: upload_accepted_event
+        description: Indicates that an upload was by downstream services
       - topic: file_interrogation
         type: file_validation_failure
         config: upload_rejected_event
+        description: Informing about rejection of an upload by downstream services due to validation failure
     produces:
       - topic: file_uploads
         type: file_upload_received
         config: upload_received_event
+        description: Informing about new file uploads
   rest:
     produces:
       - method: GET

--- a/services/wps.yaml
+++ b/services/wps.yaml
@@ -1,8 +1,7 @@
 shortname: wps
 name: work-package-service
-summary: |
-  The work package service manages work packages 
-  that can be used by the GHGA CLI client.
+summary: "The work package service manages work packages 
+          that can be used by the GHGA CLI client."
 version: main
 storage:
   mongodb:

--- a/services/wps.yaml
+++ b/services/wps.yaml
@@ -1,0 +1,11 @@
+shortname: wps
+name: work-package-service
+summary: |
+  The work package service manages work packages 
+  that can be used by the GHGA CLI client.
+version: main
+storage:
+  mongodb:
+    - db_name: wps
+      mode: read-write
+  


### PR DESCRIPTION
All project names "{some_name}-service" are added. 

Some discussion points:
- Data Portal UI and Metadata Catalog were also added. They are not standard services and only consumers. 
- Initials used for shortname for all services but some have env. variables starting with their long name. Generating variables like "{shortname}_{variable_str}" will not work for those services. (eg. METADATA_REPOSITORY_SERVICE_CONFIG_YAML.)
- Auth Service, service normally uses the **oidc_authority_url** (default: https://proxy.aai.lifescience-ri.eu). Should we include it in the consumed REST endpoints?
-  I wrote the authentication value as True for all REST endpoints but for example, Metadata Search Service has endpoints that are public at the moment, I am not sure about the "authentication" value for services, since I didn't find any auth checks in the code or any openapi.yaml.